### PR TITLE
Kotlin 2.0.0 Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/
 out/
 .idea/
 *.iml
+
+.kotlin

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.0")
     implementation("com.palantir.gradle.gitversion:gradle-git-version:3.0.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,3 @@
 plugins {
-    kotlin("jvm") version "1.8.21" apply false
+    kotlin("jvm") version "2.0.0" apply false
 }

--- a/kapshot-plugin-gradle/src/main/kotlin/io/koalaql/kapshot/GradlePlugin.kt
+++ b/kapshot-plugin-gradle/src/main/kotlin/io/koalaql/kapshot/GradlePlugin.kt
@@ -22,7 +22,7 @@ class GradlePlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
         /* make sure we don't try to add dependency until it has been configured by kotlin plugin */
         target.plugins.withId("org.jetbrains.kotlin.jvm") {
-            target.dependencies.add("implementation", "io.koalaql:kapshot-runtime:${BuildConfig.VERSION}")
+            target.dependencies.add("api", "io.koalaql:kapshot-runtime:${BuildConfig.VERSION}")
         }
     }
 

--- a/kapshot-plugin-kotlin/build.gradle.kts
+++ b/kapshot-plugin-kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("publish")
 
-    kotlin("kapt") version "1.8.21"
+    kotlin("kapt") version "2.0.0"
 }
 
 dependencies {

--- a/kapshot-plugin-kotlin/build.gradle.kts
+++ b/kapshot-plugin-kotlin/build.gradle.kts
@@ -1,12 +1,7 @@
 plugins {
     id("publish")
-
-    kotlin("kapt") version "2.0.0"
 }
 
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable")
-
-    kapt("com.google.auto.service:auto-service:1.0.1")
-    compileOnly("com.google.auto.service:auto-service-annotations:1.0.1")
 }

--- a/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/CaptureTransformer.kt
+++ b/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/CaptureTransformer.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.ir.expressions.IrTypeOperator
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrConstImpl
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.kotlinFqName
@@ -20,6 +21,8 @@ import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
 
+/* this service is registered under resources/META-INF/services */
+@OptIn(UnsafeDuringIrConstructionAPI::class)
 class CaptureTransformer(
     private val context: IrPluginContext,
     private val projectDir: Path,

--- a/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/CaptureTransformer.kt
+++ b/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/CaptureTransformer.kt
@@ -3,7 +3,6 @@ package io.koalaql.kapshot.plugin
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
-import org.jetbrains.kotlin.backend.common.sourceElement
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irString
@@ -16,6 +15,7 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.kotlinFqName
+import org.jetbrains.kotlin.ir.util.sourceElement
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path

--- a/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/CliProcessor.kt
+++ b/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/CliProcessor.kt
@@ -1,13 +1,12 @@
 package io.koalaql.kapshot.plugin
 
-import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
-@AutoService(CommandLineProcessor::class)
+/* this service is registered under resources/META-INF/services */
 @OptIn(ExperimentalCompilerApi::class)
 class CliProcessor: CommandLineProcessor {
     override val pluginId: String = "io.koalaql.kapshot-plugin"

--- a/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/Registrar.kt
+++ b/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/Registrar.kt
@@ -1,6 +1,5 @@
 package io.koalaql.kapshot.plugin
 
-import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -8,7 +7,6 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import kotlin.io.path.Path
 
-@AutoService(CompilerPluginRegistrar::class)
 @OptIn(ExperimentalCompilerApi::class)
 class Registrar: CompilerPluginRegistrar() {
     override val supportsK2: Boolean get() = true

--- a/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/Registrar.kt
+++ b/kapshot-plugin-kotlin/src/main/kotlin/io/koalaql/kapshot/plugin/Registrar.kt
@@ -11,7 +11,7 @@ import kotlin.io.path.Path
 @AutoService(CompilerPluginRegistrar::class)
 @OptIn(ExperimentalCompilerApi::class)
 class Registrar: CompilerPluginRegistrar() {
-    override val supportsK2: Boolean get() = false
+    override val supportsK2: Boolean get() = true
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
         IrGenerationExtension.registerExtension(GenerationExtension(

--- a/kapshot-plugin-kotlin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/kapshot-plugin-kotlin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+io.koalaql.kapshot.plugin.CliProcessor

--- a/kapshot-plugin-kotlin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+++ b/kapshot-plugin-kotlin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -1,0 +1,1 @@
+io.koalaql.kapshot.plugin.Registrar


### PR DESCRIPTION
* Support for Kotlin 2.0.0
* Remove Kapt dependency from plugin build
* Runtime dependencies are configured as `api` rather than `implementation` (closes #10)